### PR TITLE
[Do not merge. Question] toggle barStyle in examples

### DIFF
--- a/Examples/UIExplorer/js/NavigatorIOSBarStyleExample.js
+++ b/Examples/UIExplorer/js/NavigatorIOSBarStyleExample.js
@@ -23,6 +23,7 @@
 var React = require('react');
 var ReactNative = require('react-native');
 var {
+  Button,
   NavigatorIOS,
   StatusBar,
   StyleSheet,
@@ -37,12 +38,31 @@ class EmptyPage extends React.Component {
         <Text style={styles.emptyPageText}>
           {this.props.text}
         </Text>
+        <Button
+          title="Toggle Bar Style"
+          color="#841584"
+          onPress={this.props.toggleBarStyle}
+        />
       </View>
     );
   }
 }
 
 class NavigatorIOSColors extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.toggleBarStyle = this.toggleBarStyle.bind(this);
+
+    this.state = { barStyle: 'black' };
+  }
+
+  toggleBarStyle() {
+    let newBarStyle = this.state.barStyle === 'default' ? 'black' : 'default';
+    console.log(newBarStyle)
+    this.setState({ barStyle: newBarStyle });
+  }
+
   static title = '<NavigatorIOS> - Custom Bar Style';
   static description = 'iOS navigation with custom nav bar colors';
 
@@ -56,16 +76,21 @@ class NavigatorIOSColors extends React.Component {
         initialRoute={{
           component: EmptyPage,
           title: '<NavigatorIOS>',
-          rightButtonTitle: 'Done',
+          rightButtonTitle: 'Toggle',
+          leftButtonTitle: 'Done',
           onRightButtonPress: () => {
+            this.toggleBarStyle();
+          },
+          onLeftButtonPress: () => {
             StatusBar.setBarStyle('default');
             this.props.onExampleExit();
           },
           passProps: {
-            text: 'The nav bar is black with barStyle prop.',
+            text: `The barStyle is ${this.state.barStyle}`,
+            toggleBarStyle: this.toggleBarStyle,
           },
         }}
-        barStyle="black"
+        barStyle={this.state.barStyle}
       />
     );
   }

--- a/Examples/UIExplorer/js/TabBarIOSCustomBarStyle.js
+++ b/Examples/UIExplorer/js/TabBarIOSCustomBarStyle.js
@@ -25,6 +25,7 @@
 var React = require('react');
 var ReactNative = require('react-native');
 var {
+  Button,
   StyleSheet,
   TabBarIOS,
   Text,
@@ -34,19 +35,38 @@ var {
 var base64Icon = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAABLCAQAAACSR7JhAAADtUlEQVR4Ac3YA2Bj6QLH0XPT1Fzbtm29tW3btm3bfLZtv7e2ObZnms7d8Uw098tuetPzrxv8wiISrtVudrG2JXQZ4VOv+qUfmqCGGl1mqLhoA52oZlb0mrjsnhKpgeUNEs91Z0pd1kvihA3ULGVHiQO2narKSHKkEMulm9VgUyE60s1aWoMQUbpZOWE+kaqs4eLEjdIlZTcFZB0ndc1+lhB1lZrIuk5P2aib1NBpZaL+JaOGIt0ls47SKzLC7CqrlGF6RZ09HGoNy1lYl2aRSWL5GuzqWU1KafRdoRp0iOQEiDzgZPnG6DbldcomadViflnl/cL93tOoVbsOLVM2jylvdWjXolWX1hmfZbGR/wjypDjFLSZIRov09BgYmtUqPQPlQrPapecLgTIy0jMgPKtTeob2zWtrGH3xvjUkPCtNg/tm1rjwrMa+mdUkPd3hWbH0jArPGiU9ufCsNNWFZ40wpwn+62/66R2RUtoso1OB34tnLOcy7YB1fUdc9e0q3yru8PGM773vXsuZ5YIZX+5xmHwHGVvlrGPN6ZSiP1smOsMMde40wKv2VmwPPVXNut4sVpUreZiLBHi0qln/VQeI/LTMYXpsJtFiclUN+5HVZazim+Ky+7sAvxWnvjXrJFneVtLWLyPJu9K3cXLWeOlbMTlrIelbMDlrLenrjEQOtIF+fuI9xRp9ZBFp6+b6WT8RrxEpdK64BuvHgDk+vUy+b5hYk6zfyfs051gRoNO1usU12WWRWL73/MMEy9pMi9qIrR4ZpV16Rrvduxazmy1FSvuFXRkqTnE7m2kdb5U8xGjLw/spRr1uTov4uOgQE+0N/DvFrG/Jt7i/FzwxbA9kDanhf2w+t4V97G8lrT7wc08aA2QNUkuTfW/KimT01wdlfK4yEw030VfT0RtZbzjeMprNq8m8tnSTASrTLti64oBNdpmMQm0eEwvfPwRbUBywG5TzjPCsdwk3IeAXjQblLCoXnDVeoAz6SfJNk5TTzytCNZk/POtTSV40NwOFWzw86wNJRpubpXsn60NJFlHeqlYRbslqZm2jnEZ3qcSKgm0kTli3zZVS7y/iivZTweYXJ26Y+RTbV1zh3hYkgyFGSTKPfRVbRqWWVReaxYeSLarYv1Qqsmh1s95S7G+eEWK0f3jYKTbV6bOwepjfhtafsvUsqrQvrGC8YhmnO9cSCk3yuY984F1vesdHYhWJ5FvASlacshUsajFt2mUM9pqzvKGcyNJW0arTKN1GGGzQlH0tXwLDgQTurS8eIQAAAABJRU5ErkJggg==';
 
 class TabBarExample extends React.Component {
+  constructor (props) {
+    super(props);
+    this.state = {
+      barStyle: 'default',
+    };
+
+    this.toggleBarStyle = this.toggleBarStyle.bind(this);
+  }
+
   static title = '<TabBarIOS> - Custom Bar Style';
   static description = 'Tab-based navigation.';
   static displayName = 'TabBarExample';
 
+  toggleBarStyle () {
+    let newBarStyle = this.state.barStyle === 'default' ? 'black' : 'default';
+    this.setState({ barStyle: newBarStyle });
+  }
+
   render() {
     return (
-      <TabBarIOS barStyle="black">
+      <TabBarIOS barStyle={this.state.barStyle}>
         <TabBarIOS.Item
           title="Tab"
           icon={{uri: base64Icon, scale: 3}}
           selected>
           <View style={styles.tabContent}>
             <Text style={styles.tabText}>Single page</Text>
+            <Button
+              title="Learn More"
+              color="#841584"
+              onPress={this.toggleBarStyle}
+            />
           </View>
         </TabBarIOS.Item>
       </TabBarIOS>


### PR DESCRIPTION
@jacobp100 Hi, I pulled down your branch to make sure I understood what your pull request  [10936](https://github.com/facebook/react-native/pull/10936) was doing.

I was able to edit the TabBarIOS example so it toggles `barStyle` but I was unable to make the same thing happen with NavigatorIOS.
Do you have any idea why it doesn't work with NavigatorIOS?

Thanks in advance for your time.